### PR TITLE
- Use expandableTextbox instead of textbox to specify multiple directories

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vs_code_metrics/VsCodeMetricsBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/vs_code_metrics/VsCodeMetricsBuilder.java
@@ -136,7 +136,7 @@ public class VsCodeMetricsBuilder extends Builder {
 
         // Location to search for assembly dependencies.
         if (!StringUtil.isNullOrSpace(directory))
-            args.add(StringUtil.convertArgumentWithQuote("directory", directory));
+            args.addAll(getArguments(build, env, "directory", directory));
 
         // Search the Global Assembly Cache for missing references.
         if (searchGac)

--- a/src/main/resources/org/jenkinsci/plugins/vs_code_metrics/VsCodeMetricsBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vs_code_metrics/VsCodeMetricsBuilder/config.jelly
@@ -21,7 +21,7 @@
     <f:advanced>
 
         <f:entry title="${%Directory}" field="directory">
-            <f:textbox name="VsCodeMetricsBuilder.directory" value="${instance.directory}" />
+            <f:expandableTextbox name="VsCodeMetricsBuilder.directory" value="${instance.directory}" />
         </f:entry>
 
         <f:entry title="${%SearchGac}" field="searchGac">


### PR DESCRIPTION
Metrics.exe /directory: option can be specified multiple arguments as well as /file option.

For example, 
Metrics.exe /file:"hoge.dll" /file:"fuga.dll" /out:"metrics.xml" /directory:"dirA" /directory:"dirB"
